### PR TITLE
Fix a bug with recursive mutex.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ DEFINES=-D_FILE_OFFSET_BITS=64 \
 	-DBACKFS_RW
 
 CFLAGS=-std=c11 -Wall -Wextra -pedantic -gstabs $(DEFINES) -I/usr/include/fuse
-LDFLAGS=-lfuse
+LDFLAGS=-lfuse -lpthread
 
 CFLAGS+= -Wno-format		# we use the Gnu '%m' format all over the place
 CFLAGS+= -Wno-sign-compare	# these should get fixed eventually, but there are a lot...

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 PREFIX=/usr/local
 
-VERSION=BackFS v0.4pre\
-$(shell test -d .git && echo "\ngit revision" && git log --pretty="format:%h %ai" -n1)\
+BRANCH=$(shell test -d .git && (git branch | grep '^*' | cut -c3-) || echo "unknown")
+
+VERSION=BackFS v0.4\
+$(shell test -d .git && echo "\ngit revision" && git log --pretty="format:%h %ai" -n1) branch $(BRANCH)\
 \nbuilt $(shell date "+%Y-%m-%d %H:%M:%S %z")\n
 
 DEFINES=-D_FILE_OFFSET_BITS=64 \
@@ -9,15 +11,13 @@ DEFINES=-D_FILE_OFFSET_BITS=64 \
 	-D_POSIX_C_SOURCE=201201 \
 	-D_GNU_SOURCE \
 	-DBACKFS_VERSION="\"$(VERSION)\"" \
+	-DBACKFS_RW
 
-BRANCH=$(shell test -d .git && (git branch | grep '^*' | cut -c3-) || echo "unknown")
-
-ifeq ($(BRANCH),rw)
-	DEFINES+= -DBACKFS_RW
-endif
-
-CFLAGS=-std=c1x -pedantic -g3 $(DEFINES) -I/usr/include/fuse
+CFLAGS=-std=c11 -Wall -Wextra -pedantic -gstabs $(DEFINES) -I/usr/include/fuse
 LDFLAGS=-lfuse
+
+CFLAGS+= -Wno-format		# we use the Gnu '%m' format all over the place
+CFLAGS+= -Wno-sign-compare	# these should get fixed eventually, but there are a lot...
 
 CC = gcc
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Strictly speaking, the last step isn't needed, because once buckets aren't linke
 Todo List
 ---------
 
-* Make BackFS a write-through cache.
+* ???
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 BackFS
 ======
 
-BackFS is a read-only FUSE filesystem designed to provide a large local disk cache for a remote network filesystem.
+BackFS is a FUSE filesystem designed to provide a large local disk cache for a remote network filesystem.
 
 Say you have a network filesystem, such as a SSH or FTP mounted share, and the connection to that share is rather slow.
 Locally, you have a sizable amount of disk space to spare, but not enough to make a complete local copy of the remote share.
@@ -76,6 +76,10 @@ Options
        - optional: size (in bytes) of the blocks stored in the cache.
          A read resulting in a cache miss will fetch this amount from the backing store.
          If unspecified, the default is 1 MiB (1048576 bytes).
+
+* `-o rw`
+       - optional: enable read-write mode. By default, BackFS operates as a read-only filesystem.
+         This option allows BackFS to function as a write-through cache.
 
 Requirements
 ------------

--- a/backfs.c
+++ b/backfs.c
@@ -358,12 +358,13 @@ int backfs_readlink(const char *path, char *buf, size_t bufsize)
 
     REALPATH(real, path);
 
-    ssize_t bytes_written = readlink(real, buf, bufsize);
+    ssize_t bytes_written = readlink(real, buf, bufsize-1);
     if (bytes_written == -1)
     {
         ret = -errno;
         goto exit;
     }
+    buf[bufsize] = '\0';
 
 exit:
     FREE(real);

--- a/backfs.c
+++ b/backfs.c
@@ -476,8 +476,15 @@ int backfs_read(const char *path, char *rbuf, size_t size, off_t offset,
 
         // in case another thread is reading a full block as a result of a 
         // cache miss
-        pthread_mutex_lock(&backfs.lock);
-        locked = true;
+        if (!locked)
+        {
+            ret = pthread_mutex_lock(&backfs.lock);
+            if (ret) {
+                DEBUG("Error locking mutex: %d!", ret);
+                goto exit;
+            }
+            locked = true;
+        }
 
         if (first) {
             DEBUG("reading from 0x%lx to 0x%lx, block size is 0x%lx\n",
@@ -1472,6 +1479,9 @@ int main(int argc, char **argv)
     printf("initializing cache and scanning existing cache dir...\n");
     cache_init(backfs.cache_dir, backfs.cache_size, backfs.block_size);
 
+    // Initializing mutex
+    pthread_mutex_init(&backfs.lock, NULL);
+    
     printf("ready to go!\n");
     backfs_fuse_main(args.argc, args.argv, &BackFS_Opers);
 

--- a/backfs.c
+++ b/backfs.c
@@ -476,15 +476,12 @@ int backfs_read(const char *path, char *rbuf, size_t size, off_t offset,
 
         // in case another thread is reading a full block as a result of a 
         // cache miss
-        if (!locked)
-        {
-            ret = pthread_mutex_lock(&backfs.lock);
-            if (ret) {
-                DEBUG("Error locking mutex: %d!", ret);
-                goto exit;
-            }
-            locked = true;
+        ret = pthread_mutex_lock(&backfs.lock);
+        if (ret) {
+            DEBUG("Error locking mutex: %d!", ret);
+            goto exit;
         }
+        locked = true;
 
         if (first) {
             DEBUG("reading from 0x%lx to 0x%lx, block size is 0x%lx\n",

--- a/fscache.c
+++ b/fscache.c
@@ -987,7 +987,7 @@ int cache_add(const char *filename, uint32_t block, const char *buf,
             (unsigned long long) bytes_written);
 
     bool unchecked = is_unchecked(bucketpath);
-    if (unchecked) {
+    if (!unchecked) {
       cache_used_size += bytes_written;
     }
 
@@ -1019,7 +1019,7 @@ int cache_add(const char *filename, uint32_t block, const char *buf,
             (unsigned long long) more_bytes_written,
             (unsigned long long) more_bytes_written + bytes_written);
 
-        if (unchecked) {
+        if (!unchecked) {
           cache_used_size += more_bytes_written;
         }
         bytes_written += more_bytes_written;

--- a/fscache.c
+++ b/fscache.c
@@ -37,41 +37,72 @@ extern bool backfs_log_stderr;
 
 static char *cache_dir;
 static uint64_t cache_size;
-static uint64_t cache_used_size;
+static volatile uint64_t cache_used_size = 0;
+struct bucket_node { char path[PATH_MAX]; struct bucket_node* next; };
+static struct bucket_node * volatile to_check;
 static bool use_whole_device;
 static uint64_t bucket_max_size;
 
-uint64_t get_cache_used_size(const char *root)
+uint64_t cache_number_of_buckets(const char *root)
 {
     INFO("taking inventory of cache directory\n");
     uint64_t total = 0;
     struct dirent *e = malloc(offsetof(struct dirent, d_name) + PATH_MAX + 1);
     struct dirent *result = e;
-    struct stat s;
-    char buf[PATH_MAX];
     DIR *dir = opendir(root);
+    struct bucket_node* volatile * next = &to_check;
     while (readdir_r(dir, e, &result) == 0 && result != NULL) {
         if (e->d_name[0] < '0' || e->d_name[0] > '9') continue;
-        snprintf(buf, PATH_MAX, "%s/%s/data", root, e->d_name);
-        s.st_size = 0;
-        if (stat(buf, &s) == -1 && errno != ENOENT) {
-            PERROR("stat in get_cache_used_size");
-            ERROR("\tcaused by stat(%s)\n", buf);
-            abort();
-        }
-        DEBUG("bucket %s: %llu bytes\n",
-                e->d_name, (unsigned long long) s.st_size);
-        total += s.st_size;
+        *next = (struct bucket_node*)malloc(sizeof(struct bucket_node));
+        snprintf((*next)->path, PATH_MAX, "%s/%s/data", root, e->d_name);
+        next = &((*next)->next);
+        *next = NULL;
+        ++total;
     }
-    if (result != NULL) {
-        PERROR("readdir in get_cache_used_size");
-        abort();
-    }
-
     closedir(dir);
     FREE(e);
 
     return total;
+}
+
+bool is_unchecked(const char* path)
+{
+  struct bucket_node* node = to_check;
+  while(node) {
+    if (strcmp(node->path, path) == 0)
+      return true;
+    node = node->next;
+  }
+  return false;
+}
+
+void* check_buckets_size(void* arg)
+{
+  struct stat s;
+  struct bucket_node* bucket;
+  if (arg != NULL) {
+    abort();
+  }
+
+  while (to_check) {
+    pthread_mutex_lock(&lock);
+    bucket = to_check;
+    if (bucket) {
+      s.st_size = 0;
+      if (stat(bucket->path, &s) == -1 && errno != ENOENT) {
+           PERROR("stat in get_cache_used_size");
+           ERROR("\tcaused by stat(%s)\n", bucket->path);
+           abort();
+       }
+       DEBUG("bucket %s: %llu bytes\n",
+               bucket->path, (unsigned long long) s.st_size);
+       cache_used_size -= bucket_max_size - s.st_size;
+       to_check = bucket->next;
+    }
+    pthread_mutex_unlock(&lock);
+    free(bucket);
+  }
+  return NULL;
 }
 
 uint64_t get_cache_fs_free_size(const char *root)
@@ -98,15 +129,23 @@ void cache_init(const char *a_cache_dir, uint64_t a_cache_size, uint64_t a_bucke
 
     char bucket_dir[PATH_MAX];
     snprintf(bucket_dir, PATH_MAX, "%s/buckets", cache_dir);
-    cache_used_size = get_cache_used_size(bucket_dir);
-    INFO("%llu bytes used in cache dir\n",
+    uint64_t number_of_buckets = cache_number_of_buckets(bucket_dir);
+    INFO("%llu buckets used in cache dir\n",
+            (unsigned long long) number_of_buckets);
+    cache_used_size = number_of_buckets * a_bucket_max_size;
+    INFO("Estimated %llu bytes used in cache dir\n",
             (unsigned long long) cache_used_size);
-
     uint64_t cache_free_size = get_cache_fs_free_size(bucket_dir);
     INFO("%llu bytes free in cache dir\n",
             (unsigned long long) cache_free_size);
 
     bucket_max_size = a_bucket_max_size;
+
+    pthread_t thread;
+    if (pthread_create(&thread, NULL, &check_buckets_size, NULL) != 0) {
+      PERROR("cache_init: error creating checked thread");
+      abort();
+    }
 }
 
 const char * bucketname(const char *path)
@@ -359,13 +398,18 @@ uint64_t free_bucket_real(const char *bucketpath, bool free_in_the_middle_is_bad
         PERROR("stat data in free_bucket");
     }
 
+    pthread_mutex_lock(&lock);
+    uint64_t result = 0;
     if (unlink(data) == -1) {
         PERROR("unlink data in free_bucket");
-        return 0;
     } else {
-        cache_used_size -= (uint64_t) s.st_size;
-        return (uint64_t) s.st_size;
+      result = (uint64_t) s.st_size;
+      if (!is_unchecked(bucketpath)) {
+        cache_used_size -= result;
+      }
     }
+    pthread_mutex_unlock(&lock);
+    return result;
 }
 
 uint64_t free_bucket_mid_queue(const char *bucketpath)
@@ -942,7 +986,10 @@ int cache_add(const char *filename, uint32_t block, const char *buf,
     DEBUG("%llu bytes written to cache\n",
             (unsigned long long) bytes_written);
 
-    cache_used_size += bytes_written;
+    bool unchecked = is_unchecked(bucketpath);
+    if (unchecked) {
+      cache_used_size += bytes_written;
+    }
 
     // for some reason (filesystem metadata overhead?) this may need to loop a
     // few times to write everything out.
@@ -972,7 +1019,9 @@ int cache_add(const char *filename, uint32_t block, const char *buf,
             (unsigned long long) more_bytes_written,
             (unsigned long long) more_bytes_written + bytes_written);
 
-        cache_used_size += more_bytes_written;
+        if (unchecked) {
+          cache_used_size += more_bytes_written;
+        }
         bytes_written += more_bytes_written;
     }
 

--- a/fscache.h
+++ b/fscache.h
@@ -13,10 +13,15 @@
 void cache_init(const char *cache_dir, uint64_t cache_size, uint64_t bucket_max_size);
 int cache_fetch(const char *filename, uint32_t block, uint64_t offset,
         char *buf, uint64_t len, uint64_t *bytes_read, time_t mtime);
-int cache_add(const char *filename, uint32_t block, char *buf, 
+int cache_add(const char *filename, uint32_t block, const char *buf, 
         uint64_t len, time_t mtime);
 int cache_invalidate_block(const char *filename, uint32_t block);
+int cache_try_invalidate_block(const char *filename, uint32_t block);
 int cache_invalidate_file(const char *filename);
-int cache_free_orphan_buckets();
+int cache_try_invalidate_file(const char *filename);
+int cache_free_orphan_buckets(void);
+int cache_has_file(const char *filename, uint64_t *cached_byte_count);
+int cache_try_invalidate_blocks_above(const char *filename, uint32_t block);
+int cache_rename(const char *path, const char *path_new);
 
 #endif //BACKFS_CACHE_WRF_H

--- a/fsll.c
+++ b/fsll.c
@@ -184,7 +184,7 @@ void fsll_to_head(const char *base, const char *path, const char *head, const ch
         }
         fsll_dump(base, head, tail);
         // cowardly refusing to break things farther
-        return;
+        goto exit;
     }
 
     if ((n == NULL) ^ (strcmp(t, path) == 0)) {
@@ -194,16 +194,16 @@ void fsll_to_head(const char *base, const char *path, const char *head, const ch
             ERROR("entry has no next but is not tail: %s\n", path);
         }
         fsll_dump(base, head, tail);
-        return;
+        goto exit;
     }
 
     if ((n != NULL) && strcmp(n, path) == 0) {
         ERROR("entry points to itself as next: %s\n", path);
-        return;
+        goto exit;
     }
     if ((p != NULL) && (strcmp(p, path) == 0)) {
         ERROR("entry points to itself as prev: %s\n", path);
-        return;
+        goto exit;
     }
 
     // there must not be the situation where the list is empty (no head or 
@@ -212,17 +212,17 @@ void fsll_to_head(const char *base, const char *path, const char *head, const ch
     if (h == NULL) {
         ERROR("fsll_to_head, no head found!\n");
         fsll_dump(base, head, tail);
-        return;
+        goto exit;
     }
     if (t == NULL) {
         ERROR("in fsll_to_head, no tail found!\n");
         fsll_dump(base, head, tail);
-        return;
+        goto exit;
     }
 
     if (p == NULL) {
         // already head; do nothing
-        return ;
+        goto exit;
     } else {
         fsll_makelink(p, "next", n);
     }
@@ -240,10 +240,11 @@ void fsll_to_head(const char *base, const char *path, const char *head, const ch
     fsll_makelink(path, "prev", NULL);
     fsll_makelink(base, head, path);
 
-    if (h) free(h);
-    if (t) free(t);
-    if (n) free(n);
-    if (p) free(p);
+exit:
+    FREE(h);
+    FREE(t);
+    FREE(n);
+    FREE(p);
 
     //fsll_dump(base, head, tail);
 }
@@ -295,10 +296,12 @@ void fsll_insert_as_tail(const char *base, const char *path, const char *head,
         fsll_makelink(t, "next", path);
         fsll_makelink(base, tail, path);
     } else {
-        if (h)
+        if (h) {
             ERROR("list has a head but no tail!\n");
-        if (t)
+        }
+        if (t) {
             ERROR("list has a tail but no head!\n");
+        }
     }
 
     if (h) free(h);

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Not sure how portable this is...
+thisScript=$(readlink /proc/$$/fd/255)
+backfsDir=$(dirname $thisScript)
+cd $backfsDir
+backfs=$backfsDir/backfs
+
+sudo umount test/cachefs
+
+rm -rf test
+mkdir test
+cd test
+mkdir cachefs
+mkdir backing_store
+mkdir mount
+
+# Copy our source code to use as the backing store.
+cp -v $backfsDir/*.c backing_store
+cp -v $backfsDir/*.h backing_store
+
+dd if=/dev/zero of=cachefs.img bs=10M count=1
+mkfs.ext2 -m 0 -F cachefs.img
+sudo mount -o loop cachefs.img cachefs
+sudo chown -R `whoami` cachefs
+
+valgrind --leak-check=full $backfs -d -o cache=cachefs,rw backing_store mount
+
+# do stuff...
+
+#sudo umount cachefs

--- a/util.c
+++ b/util.c
@@ -31,7 +31,8 @@ size_t max_filename_length(const char* path)
         PERROR("statfs in max_filename_length failed");
         return 255; // Seems to be a safe default.
     }
-    return (size_t)sfs.f_namelen;
+    size_t len = (size_t)sfs.f_namelen;
+    return len < 255 ? 255 : len;
 }
 
 /*

--- a/util.h
+++ b/util.h
@@ -8,4 +8,7 @@
 size_t max_filename_length(const char* path);
 char* areadlink(const char* path);
 
+#define FREE(var) { free(var); var = NULL; }
+#define COUNTOF(var) (sizeof(var) / sizeof(*var))
+
 #endif //BACKFS_UTIL_H


### PR DESCRIPTION
The error was a bit weird, since the original code doesn't validate the lock.
The buggy behavior was, at some point, the pthread_mutex_lock simply stall, leading to a dead_lock.

Correctly locking the mutex only once when necessary, matching the number of unlock, just fix that.